### PR TITLE
当select后跟换行符时，报SQL should start with "select "问题

### DIFF
--- a/core/src/main/java/com/github/drinkjava2/jdialects/Dialect.java
+++ b/core/src/main/java/com/github/drinkjava2/jdialects/Dialect.java
@@ -358,7 +358,7 @@ public class Dialect {
 		String trimedSql = sql.trim();
 		DialectException.assureNotEmpty(trimedSql, "sql string can not be empty");
 
-		if (!StrUtils.startsWithIgnoreCase(trimedSql, "select "))
+		if (!StrUtils.startsWithIgnoreCase(trimedSql, "select ")&&!StrUtils.startsWithIgnoreCase(trimedSql, "select\n"))
 			return (String) DialectException.throwEX("SQL should start with \"select \".");
 		String body = trimedSql.substring(7).trim();
 		DialectException.assureNotEmpty(body, "SQL body can not be empty");


### PR DESCRIPTION
当select后面未跟空格，而是换行符时，检验失败。比如以下sql:
`
String sql = "select\n  aa from t_sql";
`